### PR TITLE
Add property sheet if it doesn't already exist in portal_properties.  

### DIFF
--- a/collective/prettyphoto/exportimport.py
+++ b/collective/prettyphoto/exportimport.py
@@ -56,6 +56,8 @@ def import_various(context):
 
     # Define portal properties
     ptool = getToolByName(site, 'portal_properties')
+    if not hasattr(ptool, 'prettyphoto_properties'):
+        ptool.addPropertySheet('prettyphoto_properties', 'PrettyPhoto Properties')
     props = ptool.prettyphoto_properties
 
     for prop in _PROPERTIES:


### PR DESCRIPTION
This fixes a bug described at http://plone.293351.n2.nabble.com/Problem-to-install-PrettyPhoto-td7350043.html where the installer fails with an AttributeError: prettyphoto_properties.
